### PR TITLE
Exporting the statistic relevant to the # of nodes read during xact execution

### DIFF
--- a/core/src/main/java/org/infinispan/distribution/wrappers/CustomStatsInterceptor.java
+++ b/core/src/main/java/org/infinispan/distribution/wrappers/CustomStatsInterceptor.java
@@ -181,7 +181,6 @@ public final class CustomStatsInterceptor extends BaseCustomInterceptor {
       if (TransactionsStatisticsRegistry.isActive() && ctx.isInTxScope()) {
 
          final TransactionStatistics transactionStatistics = initStatsIfNecessary(ctx);
-         //transactionStatistics.addNTBCValue(currTimeForAllGetCommand);         
          transactionStatistics.notifyRead();
          long currCpuTime = 0;
          boolean isRemoteKey = isRemote(command.getKey());
@@ -189,6 +188,7 @@ public final class CustomStatsInterceptor extends BaseCustomInterceptor {
             currCpuTime = TransactionsStatisticsRegistry.getThreadCPUTime();
          }
          long currTimeForAllGetCommand = System.nanoTime();
+         transactionStatistics.addNTBCValue(currTimeForAllGetCommand);
          ret = invokeNextInterceptor(ctx, command);
          long lastTimeOp = System.nanoTime();
          if (isRemoteKey) {
@@ -2175,6 +2175,30 @@ public final class CustomStatsInterceptor extends BaseCustomInterceptor {
                      displayName = "Avg response time of the commit of a read only tx per tx class")
    public final long getLocalReadOnlyTxCommitResponseTimeForTxClass(@Parameter(name = "Transaction Class") String txClass) {
       return handleLong((Long) TransactionsStatisticsRegistry.getAttribute(READ_ONLY_TX_COMMIT_R, txClass));
+   }
+
+   @ManagedOperation(description = "Remote nodes from which a read-only transaction reads from per tx class",
+                     displayName = "Remote nodes read by update xacts per tx class")
+   public final long getLocalReadOnlyTxRemoteNodesReadForTxClass(@Parameter(name = "Transaction Class") String txClass) {
+      return handleLong((Long) TransactionsStatisticsRegistry.getAttribute(NUM_REMOTE_NODES_READ_RO_TX, txClass));
+   }
+
+   @ManagedOperation(description = "Remote nodes from which an update transaction reads from per tx class",
+                     displayName = "Remote nodes read by read-only xacts per tx class")
+   public final long getLocalUpdateTxRemoteNodesReadForTxClass(@Parameter(name = "Transaction Class") String txClass) {
+      return handleLong((Long) TransactionsStatisticsRegistry.getAttribute(NUM_REMOTE_NODES_READ_WR_TX, txClass));
+   }
+
+   @ManagedOperation(description = "Remote nodes from which a read-only transaction reads from",
+                     displayName = "Remote nodes read by read-only xacts")
+   public final long getLocalReadOnlyTxRemoteNodesRead() {
+      return handleLong((Long) TransactionsStatisticsRegistry.getAttribute(NUM_REMOTE_NODES_READ_RO_TX, null));
+   }
+
+   @ManagedOperation(description = "Remote nodes from which an update transaction reads from",
+                     displayName = "Remote nodes read by update xacts")
+   public final long getLocalUpdateTxRemoteNodesRead() {
+      return handleLong((Long) TransactionsStatisticsRegistry.getAttribute(NUM_REMOTE_NODES_READ_WR_TX, null));
    }
 
    //NB: readOnly transactions are never aborted (RC, RR, GMU)

--- a/core/src/main/java/org/infinispan/distribution/wrappers/RpcManagerWrapper.java
+++ b/core/src/main/java/org/infinispan/distribution/wrappers/RpcManagerWrapper.java
@@ -42,6 +42,7 @@ import org.infinispan.remoting.transport.jgroups.JGroupsTransport;
 import org.infinispan.stats.ExposedStatistic;
 import org.infinispan.stats.PiggyBackStat;
 import org.infinispan.stats.TransactionsStatisticsRegistry;
+import org.infinispan.stats.container.LocalTransactionStatistics;
 import org.infinispan.stats.container.TransactionStatistics;
 import org.infinispan.util.concurrent.NotifyingNotifiableFuture;
 import org.infinispan.util.concurrent.ResponseFuture;
@@ -305,6 +306,9 @@ public class RpcManagerWrapper implements RpcManager {
                transactionStatistics.addValue(RTT_GET_NO_WAIT, wallClockTimeTaken);
             }
          }
+         //Remote gets are routed to a *single* remote node
+         Address recipient = recipients.iterator().next();
+         ((LocalTransactionStatistics)transactionStatistics).addReadNodeIfAbsent(recipient);
       } else if (command instanceof TxCompletionNotificationCommand) {
          durationStat = ASYNC_COMPLETE_NOTIFY;
          counterStat = NUM_ASYNC_COMPLETE_NOTIFY;
@@ -377,6 +381,8 @@ public class RpcManagerWrapper implements RpcManager {
       }
       return 0;
    }
+
+
 
    private class WaitStats {
       private long numWaitedNodes;

--- a/core/src/main/java/org/infinispan/stats/ExposedStatistic.java
+++ b/core/src/main/java/org/infinispan/stats/ExposedStatistic.java
@@ -166,6 +166,9 @@ public enum ExposedStatistic {
    NUM_NODES_ROLLBACK(true, false),          //L
    NUM_NODES_COMPLETE_NOTIFY(true, false),   //L
    NUM_NODES_GET(true, false),               //L
+   NUM_REMOTE_NODES_READ_RO_TX(true,false),
+   NUM_REMOTE_NODES_READ_WR_TX(true,false),
+
 
    //Additional Stats
    TBC_EXECUTION_TIME(true, false),

--- a/core/src/main/java/org/infinispan/stats/NodeScopeStatisticCollector.java
+++ b/core/src/main/java/org/infinispan/stats/NodeScopeStatisticCollector.java
@@ -384,9 +384,9 @@ public class NodeScopeStatisticCollector {
          }
          case TX_WRITE_PERCENTAGE: {     //computed on the locally born txs
             long readTx = snapshot.getLocal(NUM_READ_ONLY_TX_COMMIT) +
-                  snapshot.getLocal(NUM_ABORTED_RO_TX);
+                    snapshot.getLocal(NUM_ABORTED_RO_TX);
             long writeTx = snapshot.getLocal(NUM_COMMITTED_WR_TX) +
-                  snapshot.getLocal(NUM_ABORTED_WR_TX);
+                    snapshot.getLocal(NUM_ABORTED_WR_TX);
             long total = readTx + writeTx;
             if (total != 0)
                return new Double(writeTx * 1.0 / total);
@@ -469,9 +469,9 @@ public class NodeScopeStatisticCollector {
          }
          case ABORT_RATE:
             long totalAbort = snapshot.getLocal(NUM_ABORTED_RO_TX) +
-                  snapshot.getLocal(NUM_ABORTED_WR_TX);
+                    snapshot.getLocal(NUM_ABORTED_WR_TX);
             long totalCommitAndAbort = snapshot.getLocal(NUM_READ_ONLY_TX_COMMIT) +
-                  snapshot.getLocal(NUM_COMMITTED_WR_TX) + totalAbort;
+                    snapshot.getLocal(NUM_COMMITTED_WR_TX) + totalAbort;
             if (totalCommitAndAbort != 0) {
                return new Double(totalAbort * 1.0 / totalCommitAndAbort);
             }
@@ -481,18 +481,18 @@ public class NodeScopeStatisticCollector {
          }
          case ARRIVAL_RATE:
             long localCommittedTx = snapshot.getLocal(NUM_READ_ONLY_TX_COMMIT) +
-                  snapshot.getLocal(NUM_COMMITTED_WR_TX);
+                    snapshot.getLocal(NUM_COMMITTED_WR_TX);
             long localAbortedTx = snapshot.getLocal(NUM_ABORTED_RO_TX) +
-                  snapshot.getLocal(NUM_ABORTED_WR_TX);
+                    snapshot.getLocal(NUM_ABORTED_WR_TX);
             long remoteCommittedTx = snapshot.getRemote(NUM_READ_ONLY_TX_COMMIT) +
-                  snapshot.getRemote(NUM_COMMITTED_WR_TX);
+                    snapshot.getRemote(NUM_COMMITTED_WR_TX);
             long remoteAbortedTx = snapshot.getRemote(NUM_ABORTED_RO_TX) +
-                  snapshot.getRemote(NUM_ABORTED_WR_TX);
+                    snapshot.getRemote(NUM_ABORTED_WR_TX);
             long totalBornTx = localAbortedTx + localCommittedTx + remoteAbortedTx + remoteCommittedTx;
             return new Double(totalBornTx * 1.0 / convertNanosToSeconds(System.nanoTime() - snapshot.getLastResetTime()));
          case THROUGHPUT:
             long totalLocalBornTx = snapshot.getLocal(NUM_READ_ONLY_TX_COMMIT) +
-                  snapshot.getLocal(NUM_COMMITTED_WR_TX);
+                    snapshot.getLocal(NUM_COMMITTED_WR_TX);
             return new Double(totalLocalBornTx * 1.0 / convertNanosToSeconds(System.nanoTime() - snapshot.getLastResetTime()));
          case LOCK_HOLD_TIME_LOCAL:
             return microAvgLocal(snapshot, NUM_HELD_LOCKS, LOCK_HOLD_TIME);
@@ -500,17 +500,17 @@ public class NodeScopeStatisticCollector {
             return microAvgRemote(snapshot, NUM_HELD_LOCKS, LOCK_HOLD_TIME);
          case NUM_COMMITS:
             return new Long(snapshot.getLocal(NUM_READ_ONLY_TX_COMMIT) +
-                                  snapshot.getLocal(NUM_COMMITTED_WR_TX) +
-                                  snapshot.getRemote(NUM_READ_ONLY_TX_COMMIT) +
-                                  snapshot.getRemote(NUM_COMMITTED_WR_TX));
+                    snapshot.getLocal(NUM_COMMITTED_WR_TX) +
+                    snapshot.getRemote(NUM_READ_ONLY_TX_COMMIT) +
+                    snapshot.getRemote(NUM_COMMITTED_WR_TX));
          case NUM_LOCAL_COMMITS:
             return new Long(snapshot.getLocal(NUM_READ_ONLY_TX_COMMIT) +
-                                  snapshot.getLocal(NUM_COMMITTED_WR_TX));
+                    snapshot.getLocal(NUM_COMMITTED_WR_TX));
          case WRITE_SKEW_PROBABILITY:
             long totalTxs = snapshot.getLocal(NUM_READ_ONLY_TX_COMMIT) +
-                  snapshot.getLocal(NUM_COMMITTED_WR_TX) +
-                  snapshot.getLocal(NUM_ABORTED_RO_TX) +
-                  snapshot.getLocal(NUM_ABORTED_WR_TX);
+                    snapshot.getLocal(NUM_COMMITTED_WR_TX) +
+                    snapshot.getLocal(NUM_ABORTED_RO_TX) +
+                    snapshot.getLocal(NUM_ABORTED_WR_TX);
             if (totalTxs != 0) {
                long writeSkew = snapshot.getLocal(NUM_WRITE_SKEW);
                return new Double(writeSkew * 1.0 / totalTxs);
@@ -518,10 +518,10 @@ public class NodeScopeStatisticCollector {
             return new Double(0);
          case NUM_GET:
             return snapshot.getLocal(NUM_SUCCESSFUL_GETS_WR_TX) +
-                  snapshot.getLocal(NUM_SUCCESSFUL_GETS_RO_TX);
+                    snapshot.getLocal(NUM_SUCCESSFUL_GETS_RO_TX);
          case NUM_LOCAL_REMOTE_GET:
             return snapshot.getLocal(NUM_SUCCESSFUL_REMOTE_GETS_WR_TX) +
-                  snapshot.getLocal(NUM_SUCCESSFUL_REMOTE_GETS_RO_TX);
+                    snapshot.getLocal(NUM_SUCCESSFUL_REMOTE_GETS_RO_TX);
          case NUM_PUT:
             return snapshot.getLocal(NUM_SUCCESSFUL_PUTS_WR_TX);
          case NUM_REMOTE_PUT:
@@ -532,7 +532,7 @@ public class NodeScopeStatisticCollector {
                return new Long(0L);
             } else {
                long local_get_time = snapshot.getLocal(ALL_GET_EXECUTION) -
-                     snapshot.getLocal(LOCAL_REMOTE_GET_R);
+                       snapshot.getLocal(LOCAL_REMOTE_GET_R);
 
                return new Long(convertNanosToMicro(local_get_time) / num);
             }
@@ -628,6 +628,10 @@ public class NodeScopeStatisticCollector {
             return snapshot.getLocal(NUM_TO_GMU_PREPARE_COMMAND_RTT_NO_WAITED);
          case RTT_GET_NO_WAIT:
             return microAvgLocal(snapshot, NUM_RTT_GET_NO_WAIT, RTT_GET_NO_WAIT);
+         case NUM_REMOTE_NODES_READ_RO_TX:
+            return avgDoubleLocal(snapshot, NUM_COMMITTED_RO_TX, NUM_REMOTE_NODES_READ_RO_TX);
+         case NUM_REMOTE_NODES_READ_WR_TX:
+            return avgDoubleLocal(snapshot, NUM_COMMITTED_WR_TX, NUM_REMOTE_NODES_READ_WR_TX);
          default:
             throw new NoIspnStatException("Invalid statistic " + param);
       }


### PR DESCRIPTION
This is actually old code, that I wrote to check something on the fly. Basically I populate the set of nodes a transaction reads from at runtime.
In particular, I think the "iterator" stuff can be improved (maybe you can tell me how you would do it).
Hope there's no big issues
